### PR TITLE
Adapt CS to core changes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,9 +15,58 @@ return (new PhpCsFixer\Config())
         '@PER-CS' => true,
         '@PHP8x2Migration' => true,
         'trailing_comma_in_multiline' => false,
-        'cast_spaces' => false,
+        'cast_spaces' => ['space' => 'none'],
         'single_line_empty_body' => false,
-        'no_unused_imports' => true
+        'no_unused_imports' => true,
+        // rules for phpdoc
+        // Removes @param, @return and @var tags that don't provide any useful information - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:no_superfluous_phpdoc_tags
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'remove_inheritdoc' => true,
+        ],
+        // require phpdoc for non typed arguments - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_add_missing_param_annotation
+        'phpdoc_add_missing_param_annotation' => true,
+        // no @access - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_no_access
+        'phpdoc_no_access' => true,
+        // no @package - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_no_package
+        'phpdoc_no_package' => true,
+        // order phpdoc tags - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_order
+        'phpdoc_order' => ['order' => ['since', 'var', 'see', 'param', 'return', 'throw', 'todo', 'deprecated']],
+        // phpdoc param in same order as signature - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_param_order
+        'phpdoc_param_order' => true,
+        // align tags - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_align
+        'phpdoc_align' => [
+            'align' => 'vertical',
+            'tags' => [
+                'param',
+                'property',
+                'property-read',
+                'property-write',
+                'phpstan-param',
+                'phpstan-property',
+                'phpstan-property-read',
+                'phpstan-property-write',
+                'phpstan-assert',
+                'phpstan-assert-if-true',
+                'phpstan-assert-if-false',
+                'psalm-param',
+                'psalm-param-out',
+                'psalm-property',
+                'psalm-property-read',
+                'psalm-property-write',
+                'psalm-assert',
+                'psalm-assert-if-true',
+                'psalm-assert-if-false'
+            ],
+        ],
+        // Check types case - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_types
+        'phpdoc_types' => true,
+        // Use native scalar types - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_scalar
+        'phpdoc_scalar' => true,
+        // remove extra empty lines - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_trim
+        'phpdoc_trim' => true,
+        // remove empty lines inside phpdoc block - https://mlocati.github.io/php-cs-fixer-configurator/#version:3.90|fixer:phpdoc_trim_consecutive_blank_line_separation
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
     ])
     ->setFinder($finder)
 ;

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -16,6 +16,8 @@
      <!-- Include the whole PSR12 standard -->
      <rule ref="PSR12"/>
 
+     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
      <!-- Comments rules from PEAR standard -->
      <rule ref="PEAR.Commenting.ClassComment">
          <exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag"/>
@@ -23,6 +25,26 @@
          <exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag"/>
          <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag"/>
      </rule>
-     <rule ref="PEAR.Commenting.FunctionComment"/>
+     <rule ref="Galette.Commenting.FunctionComment"/>
      <rule ref="PEAR.Commenting.InlineComment"/>
+
+     <!-- Type hinting -->
+     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+     </rule>
+     <!-- Force native typehint on methods properties -->
+     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
+     </rule>
+     <!-- Force native typehint on methods return -->
+     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
+     </rule>
+     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+       <properties>
+         <property name="spacesCountAroundEqualsSign" value="0"/>
+       </properties>
+     </rule>
+     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
+     <rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
 </ruleset>

--- a/lib/GaletteHelloasso/Controllers/HelloassoController.php
+++ b/lib/GaletteHelloasso/Controllers/HelloassoController.php
@@ -103,8 +103,6 @@ class HelloassoController extends AbstractPluginController
         $adherent = new Adherent($this->zdb);
         $contribution_type = new ContributionsTypes($this->zdb, (int)$helloasso_request['item_id']);
 
-        $current_url = $this->preferences->getURL();
-
         // Check the amount
         $item_id = $helloasso_request['item_id'];
         $helloasso_amounts = $helloasso->getAmounts($this->login);

--- a/lib/GaletteHelloasso/Controllers/HelloassoController.php
+++ b/lib/GaletteHelloasso/Controllers/HelloassoController.php
@@ -54,13 +54,8 @@ class HelloassoController extends AbstractPluginController
 
     /**
      * Main form
-     *
-     * @param Request  $request  PSR Request
-     * @param Response $response PSR Response
-     *
-     * @return Response
      */
-    public function form(Request $request, Response $response): Response
+    public function form(Response $response): Response
     {
         $helloasso = new Helloasso($this->zdb, $this->preferences);
 
@@ -100,18 +95,13 @@ class HelloassoController extends AbstractPluginController
 
     /**
      * Checkout form
-     *
-     * @param Request  $request  PSR Request
-     * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function formCheckout(Request $request, Response $response): Response
     {
         $helloasso_request = $request->getParsedBody();
         $helloasso = new Helloasso($this->zdb, $this->preferences);
         $adherent = new Adherent($this->zdb);
-        $contribution_type = new ContributionsTypes($this->zdb, (int) $helloasso_request['item_id']);
+        $contribution_type = new ContributionsTypes($this->zdb, (int)$helloasso_request['item_id']);
 
         $current_url = $this->preferences->getURL();
 
@@ -165,15 +155,10 @@ class HelloassoController extends AbstractPluginController
     /**
      * Logs page
      *
-     * @param Request         $request  PSR Request
-     * @param Response        $response PSR Response
-     * @param string|null     $option   Either order, reset or page
-     * @param string|int|null $value    Option value
-     *
-     * @return Response
+     * @param string|null     $option Either order, reset or page
+     * @param string|int|null $value  Option value
      */
     public function logs(
-        Request $request,
         Response $response,
         ?string $option = null,
         string|int|null $value = null
@@ -190,7 +175,7 @@ class HelloassoController extends AbstractPluginController
         if ($option !== null) {
             switch ($option) {
                 case 'page':
-                    $filters->current_page = (int) $value;
+                    $filters->current_page = (int)$value;
                     break;
                 case 'order':
                     $filters->orderby = $value;
@@ -229,11 +214,6 @@ class HelloassoController extends AbstractPluginController
 
     /**
      * Filter
-     *
-     * @param Request  $request  PSR Request
-     * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function filter(Request $request, Response $response): Response
     {
@@ -256,11 +236,6 @@ class HelloassoController extends AbstractPluginController
 
     /**
      * Preferences
-     *
-     * @param Request  $request  PSR Request
-     * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function preferences(Request $request, Response $response): Response
     {
@@ -294,11 +269,6 @@ class HelloassoController extends AbstractPluginController
 
     /**
      * Store Preferences
-     *
-     * @param Request  $request  PSR Request
-     * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function storePreferences(Request $request, Response $response): Response
     {
@@ -354,11 +324,6 @@ class HelloassoController extends AbstractPluginController
 
     /**
      * Webhook
-     *
-     * @param Request  $request  PSR Request
-     * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function webhook(Request $request, Response $response): Response
     {
@@ -487,13 +452,8 @@ class HelloassoController extends AbstractPluginController
 
     /**
      * Return URL
-     *
-     * @param Request  $request  PSR Request
-     * @param Response $response PSR Response
-     *
-     * @return Response
      */
-    public function returnUrl(Request $request, Response $response): Response
+    public function returnUrl(Response $response): Response
     {
         $params = [
             'page_title'    => _T('Helloasso payment success', 'helloasso')
@@ -510,13 +470,8 @@ class HelloassoController extends AbstractPluginController
 
     /**
      * Cancel URL
-     *
-     * @param Request  $request  PSR Request
-     * @param Response $response PSR Response
-     *
-     * @return Response
      */
-    public function cancelUrl(Request $request, Response $response): Response
+    public function cancelUrl(Response $response): Response
     {
         $this->flash->addMessage(
             'warning_detected',
@@ -529,11 +484,6 @@ class HelloassoController extends AbstractPluginController
 
     /**
      * Error URL
-     *
-     * @param Request  $request  PSR Request
-     * @param Response $response PSR Response
-     *
-     * @return Response
      */
     public function errorUrl(Request $request, Response $response): Response
     {

--- a/lib/GaletteHelloasso/Helloasso.php
+++ b/lib/GaletteHelloasso/Helloasso.php
@@ -99,8 +99,6 @@ class Helloasso
 
     /**
      * Load preferences form the database and amounts from core contributions types
-     *
-     * @return void
      */
     public function load(): void
     {
@@ -157,8 +155,6 @@ class Helloasso
 
     /**
      * Load amounts from core contributions types
-     *
-     * @return void
      */
     private function loadContributionsTypes(): void
     {
@@ -180,8 +176,6 @@ class Helloasso
 
     /**
      * Store values in the database
-     *
-     * @return bool
      */
     public function store(): bool
     {
@@ -280,8 +274,6 @@ class Helloasso
 
     /**
      * Store tokens
-     *
-     * @return bool
      */
     private function storeTokens(): bool
     {
@@ -337,8 +329,6 @@ class Helloasso
      * @param array<string, mixed> $metadata          Array of metadata to transmit with payment
      * @param float                $amount            Amount of payment
      * @param ?bool                $contains_donation Does the checkout contain a donation?
-     *
-     * @return array|bool
      */
     public function checkout(array $metadata, float $amount, ?bool $contains_donation = false): array|bool
     {
@@ -391,8 +381,6 @@ class Helloasso
 
     /**
      * Setup Guzzle client
-     *
-     * @return Client
      */
     public function setupClient(): Client
     {
@@ -430,8 +418,6 @@ class Helloasso
 
     /**
      * Is access token expired ?
-     *
-     * @return bool
      */
     public function isAccessTokenExpired(): bool
     {
@@ -443,8 +429,6 @@ class Helloasso
 
     /**
      * Is refresh token expired ?
-     *
-     * @return bool
      */
     public function isRefreshTokenExpired(): bool
     {
@@ -456,8 +440,6 @@ class Helloasso
 
     /**
      * Get credentials
-     *
-     * @return bool
      */
     private function getCredentials(): bool
     {
@@ -470,8 +452,6 @@ class Helloasso
 
     /**
      * Refresh credentials
-     *
-     * @return bool
      */
     private function refreshCredentials(): bool
     {
@@ -486,8 +466,6 @@ class Helloasso
      * Get client credentials
      *
      * @param array $parameters Parameters required by API
-     *
-     * @return bool
      */
     private function getClientCredentials(array $parameters): bool
     {
@@ -523,8 +501,6 @@ class Helloasso
      * Get API route
      *
      * @param ?bool $auth Get authentification route if true
-     *
-     * @return string
      */
     public function getApiRoute(?bool $auth = null): string
     {
@@ -568,8 +544,6 @@ class Helloasso
 
     /**
      * Get test mode
-     *
-     * @return bool
      */
     public function getTestMode(): bool
     {
@@ -578,8 +552,6 @@ class Helloasso
 
     /**
      * Get Helloasso organization slug
-     *
-     * @return string
      */
     public function getOrganizationSlug(): ?string
     {
@@ -588,8 +560,6 @@ class Helloasso
 
     /**
      * Get Helloasso clientId
-     *
-     * @return string
      */
     public function getClientId(): ?string
     {
@@ -598,8 +568,6 @@ class Helloasso
 
     /**
      * Get Helloasso clientSecret
-     *
-     * @return string
      */
     public function getClientSecret(): ?string
     {
@@ -639,8 +607,6 @@ class Helloasso
 
     /**
      * Is the plugin loaded?
-     *
-     * @return boolean
      */
     public function isLoaded(): bool
     {
@@ -649,8 +615,6 @@ class Helloasso
 
     /**
      * Are amounts loaded?
-     *
-     * @return boolean
      */
     public function areAmountsLoaded(): bool
     {
@@ -661,8 +625,6 @@ class Helloasso
      * Set Test mode
      *
      * @param bool $enabled True to enable test mode
-     *
-     * @return void
      */
     public function setTestMode(bool $enabled): void
     {
@@ -673,8 +635,6 @@ class Helloasso
      * Set Helloasso organization slug
      *
      * @param string $organization_slug organization slug
-     *
-     * @return void
      */
     public function setOrganizationSlug(string $organization_slug): void
     {
@@ -685,8 +645,6 @@ class Helloasso
      * Set Helloasso clientId
      *
      * @param string $client_id clientId
-     *
-     * @return void
      */
     public function setClientId(string $client_id): void
     {
@@ -697,8 +655,6 @@ class Helloasso
      * Set Helloasso clientSecret
      *
      * @param string $client_secret clientSecret
-     *
-     * @return void
      */
     public function setClientSecret(string $client_secret): void
     {
@@ -710,8 +666,6 @@ class Helloasso
      *
      * @param array<int, string> $ids     array of identifier
      * @param array<int, string> $amounts array of amounts
-     *
-     * @return void
      */
     public function setPrices(array $ids, array $amounts): void
     {
@@ -725,8 +679,6 @@ class Helloasso
      * Check if the specified contribution is active
      *
      * @param int $id type identifier
-     *
-     * @return boolean
      */
     public function isInactive(int $id): bool
     {
@@ -737,8 +689,6 @@ class Helloasso
      * Set inactives types
      *
      * @param array<int, string> $inactives array of inactives types
-     *
-     * @return void
      */
     public function setInactives(array $inactives): void
     {
@@ -747,8 +697,6 @@ class Helloasso
 
     /**
      * Unset inactives types
-     *
-     * @return void
      */
     public function unsetInactives(): void
     {

--- a/lib/GaletteHelloasso/Helloasso.php
+++ b/lib/GaletteHelloasso/Helloasso.php
@@ -193,7 +193,7 @@ class Helloasso
                     ]
                 );
 
-            $edit = $this->zdb->execute($update);
+            $this->zdb->execute($update);
 
             //store Helloasso organization slug
             $values = [
@@ -208,7 +208,7 @@ class Helloasso
                     ]
                 );
 
-            $edit = $this->zdb->execute($update);
+            $this->zdb->execute($update);
 
             //store Helloasso clientId
             $values = [
@@ -223,7 +223,7 @@ class Helloasso
                     ]
                 );
 
-            $edit = $this->zdb->execute($update);
+            $this->zdb->execute($update);
 
             //store Helloasso clientSecret
             $values = [
@@ -238,7 +238,7 @@ class Helloasso
                     ]
                 );
 
-            $edit = $this->zdb->execute($update);
+            $this->zdb->execute($update);
 
             //store inactives
             $values = [
@@ -253,7 +253,7 @@ class Helloasso
                     ]
                 );
 
-            $edit = $this->zdb->execute($update);
+            $this->zdb->execute($update);
 
             Analog::log(
                 '[' . get_class($this)

--- a/lib/GaletteHelloasso/HelloassoHistory.php
+++ b/lib/GaletteHelloasso/HelloassoHistory.php
@@ -89,7 +89,7 @@ class HelloassoHistory extends History
             $insert = $this->zdb->insert($this->getTableName());
             $insert->values($values);
             $this->zdb->execute($insert);
-            $this->id = (int) $this->zdb->driver->getLastGeneratedValue();
+            $this->id = (int)$this->zdb->driver->getLastGeneratedValue();
 
             Analog::log(
                 'An entry has been added in helloasso history',
@@ -109,9 +109,7 @@ class HelloassoHistory extends History
     /**
      * Get table's name
      *
-     * @param boolean $prefixed Whether table name should be prefixed
-     *
-     * @return string
+     * @param bool $prefixed Whether table name should be prefixed
      */
     protected function getTableName(bool $prefixed = false): string
     {
@@ -124,8 +122,6 @@ class HelloassoHistory extends History
 
     /**
      * Get table's PK
-     *
-     * @return string
      */
     protected function getPk(): string
     {
@@ -134,8 +130,6 @@ class HelloassoHistory extends History
 
     /**
      * Gets Helloasso history
-     *
-     * @return array
      */
     public function getHelloassoHistory(): array
     {
@@ -192,8 +186,6 @@ class HelloassoHistory extends History
      * Is payment already processed?
      *
      * @param array $request Verify sign helloasso parameter
-     *
-     * @return boolean
      */
     public function isProcessed(array $request): bool
     {
@@ -212,9 +204,7 @@ class HelloassoHistory extends History
     /**
      * Set payment state
      *
-     * @param integer $state State, one of self::STATE_ constants
-     *
-     * @return boolean
+     * @param int $state State, one of self::STATE_ constants
      */
     public function setState(int $state): bool
     {

--- a/tests/GaletteHelloasso/tests/units/Helloasso.php
+++ b/tests/GaletteHelloasso/tests/units/Helloasso.php
@@ -35,8 +35,6 @@ class Helloasso extends GaletteTestCase
 
     /**
      * Cleanup after each test method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -47,8 +45,6 @@ class Helloasso extends GaletteTestCase
 
     /**
      * Test empty
-     *
-     * @return void
      */
     public function testEmpty(): void
     {


### PR DESCRIPTION
I've changed some CS rules in core, in order to make some things easier (it's for example no longer needed to systematically comment methods parameters and return - typehint may be enough).

You can of course refuse those changes if you not want them in the plugin ;)