### PR TITLE
Display contribution types descriptions on form

### DIFF
--- a/templates/default/helloasso_form.html.twig
+++ b/templates/default/helloasso_form.html.twig
@@ -44,6 +44,9 @@
                                                 ({{ amount['amount']|format_currency('EUR', {}, galette_lang) }})
                                             </label>
                                         </div>
+                                        {% if amount['description'] is defined and amount['description'] is not empty %}
+                                            <div class="ui visible info message amount-description">{{ amount['description']|raw }}</div>
+                                        {% endif %}
                                     </div>
                                 {% endfor %}
                             </div>

--- a/webroot/galette_helloasso.css
+++ b/webroot/galette_helloasso.css
@@ -14,6 +14,10 @@ em[data-emoji="helloasso"]::before {
   background-image: url(./images/helloasso.svg);
 }
 
+.ui.message.amount-description {
+  margin-left:1.85714em;
+}
+
 .secured-payment {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Fixes galette-community/plugin-helloasso#14
Depends on galette/galette#793
<img width="1004" height="554" alt="helloasso" src="https://github.com/user-attachments/assets/d7655d03-4956-42fa-b5a7-29197f330ae7" />

